### PR TITLE
fix implicit declaration function

### DIFF
--- a/nginx_session_binding_proxy_module/ngx_http_session_binding_proxy_module.c
+++ b/nginx_session_binding_proxy_module/ngx_http_session_binding_proxy_module.c
@@ -171,11 +171,13 @@ static ngx_int_t ngx_http_session_binding_proxy_handler(ngx_http_request_t *r) {
     }
 
 	ngx_str_t master_key;
+	size_t  SSL_SESSION_get_master_key();
 	master_key.len = 0;
 	master_key.data = ngx_pcalloc(r->pool, SSL_MAX_MASTER_KEY_LENGTH);
 	if (master_key.data == NULL) {
         return NGX_ERROR;
     }
+
 
 	//Check if we indeed have an SSL connection
 	if (r->connection->ssl) {
@@ -391,6 +393,7 @@ static ngx_int_t ngx_http_session_binding_proxy_header_filter(ngx_http_request_t
     }
 
 	ngx_str_t							master_key;
+	size_t SSL_SESSION_get_master_key();
 	master_key.len = 0;
 	master_key.data = ngx_pcalloc(r->pool, SSL_MAX_MASTER_KEY_LENGTH);
 	if (master_key.data == NULL) {


### PR DESCRIPTION
Fix that
```
/ngx_http_session_binding_proxy_module.c:184:21: error: implicit declaration of function ‘SSL_SESSION_get_master_key’ [-Werror=implicit-function-declaration]
    master_key.len = SSL_SESSION_get_master_key(ssl_session, master_key.data, SSL_MAX_MASTER_KEY_LENGTH);
                     ^
cc1: all warnings being treated as errors
objs/Makefile:2615: recipe for target 'objs/addon/nginx_session_binding_proxy_module/ngx_http_session_binding_proxy_module.o' failed
make[3]: *** [objs/addon/nginx_session_binding_proxy_module/ngx_http_session_binding_proxy_module.o] Error 1
make[3]: Leaving directory '/<<PKGBUILDDIR>>'
```